### PR TITLE
Fix issue with login/logout on Bunpro

### DIFF
--- a/Example Sentence Audio/userscript.js
+++ b/Example Sentence Audio/userscript.js
@@ -14,7 +14,7 @@
 	// Need to remove the referrer; otherwise returns 404s
 	var remRef = document.createElement('meta');
 	remRef.name = 'referrer';
-	remRef.content = 'no-referrer';
+	remRef.content = 'same-origin';
 	document.querySelector('head').append(remRef);
 
 	// CSS stuff


### PR DESCRIPTION
This fixes an issue where this script breaks logging in and out on BunPro by removing the `origin` and `referrer` headers from all requests.

Setting it to `same-origin` instead of `no-referrer` allows the headers to still be sent within BunPro but does not send them when making requests to `translate.google.com`.